### PR TITLE
Fix search crash when empty list

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,6 +10,8 @@ jobs:
       uses: actions/checkout@master
     - name: Run tests
       uses: comigor/actions/dart-test@master
+      env:
+        DTA_EXCLUDE_REGEX: example
   check-version-and-changelog:
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,4 +1,4 @@
-on: push
+on: [push, pull_request]
 
 name: CI
 
@@ -17,24 +17,20 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - run: |
-        go get -u github.com/itchyny/gojq/cmd/gojq
+        GO111MODULE=on go get -u github.com/itchyny/gojq/cmd/gojq@d24ecb5d89a9eee8b4cd2071bdff7585a8b44f0e
         cd "$GITHUB_WORKSPACE"
     - name: Check if version on pubspec.yaml was changed and if there's an entry for this new version on CHANGELOG
       run: |
         git fetch --prune --unshallow
-
         if test "${{ github.ref }}" = "refs/heads/master"; then
           where=HEAD~$(gojq '.commits | length' "${GITHUB_EVENT_PATH}")
         else
           where=origin/master
         fi
-
         diff=$(git diff $where pubspec.yaml)
         echo "$diff" | grep -E '\+.*version'
-
         mkdir -p artifacts
         git diff -U0 $where CHANGELOG.md | grep '^\+' | grep -Ev '^(--- a/|\+\+\+ b/)' | sed -E 's/^\+(.*)/\1/g' > artifacts/changelog
-
         package_version=$(cat pubspec.yaml | gojq --yaml-input -r '.version')
         cat CHANGELOG.md | grep "$package_version"
         echo "$package_version" > artifacts/version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # CHANGELOG
+## 0.2.1
+- Fix bug for search empty list
 
 ## 0.2.0+8
 - Testing GitHub actions

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,0 +1,12 @@
+name: fuzzy_example
+version: 0.0.1
+
+authors:
+  - Igor Borges <igor@borges.dev>
+
+environment:
+  sdk: '>=2.0.0 <3.0.0'
+
+dependencies:
+  fuzzy:
+    path: ../

--- a/lib/fuzzy.dart
+++ b/lib/fuzzy.dart
@@ -30,6 +30,8 @@ class Fuzzy<T> {
 
   /// Search for a given [pattern] on the [list], optionally [limit]ing the result length
   List<Result<T>> search(String pattern, [int limit = -1]) {
+    if (list.isEmpty) return <Result<T>>[];
+
     final searchers = _prepareSearchers(pattern);
 
     final resultsAndWeights =

--- a/lib/fuzzy.dart
+++ b/lib/fuzzy.dart
@@ -18,9 +18,10 @@ export 'data/fuzzy_options.dart';
 class Fuzzy<T> {
   /// Instantiates it given a list of strings to look into, and options
   Fuzzy(
-    this.list, {
+    List<T> list, {
     FuzzyOptions<T> options,
-  }) : options = options ?? FuzzyOptions<T>();
+  })  : list = list ?? [],
+        options = options ?? FuzzyOptions<T>();
 
   /// The original list of string
   final List<T> list;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fuzzy
-version: 0.2.0+8
+version: 0.2.1
 
 authors:
   - Igor Borges <igor@borges.dev>

--- a/test/fuzzy_test.dart
+++ b/test/fuzzy_test.dart
@@ -42,6 +42,19 @@ void main() {
     });
   });
 
+  group('Null list', () {
+    Fuzzy fuse;
+    List<String> items;
+    setUp(() {
+      fuse = Fuzzy(items, options: defaultOptions);
+    });
+    test('empty result is returned', () {
+      final result = fuse.search('Bla');
+      print(result);
+      expect(result.isEmpty, true);
+    });
+  });
+
   group('Flat list of strings: ["Apple", "Orange", "Banana"]', () {
     Fuzzy fuse;
     setUp(() {

--- a/test/fuzzy_test.dart
+++ b/test/fuzzy_test.dart
@@ -31,6 +31,17 @@ Fuzzy setup({
 }
 
 void main() {
+  group('Empty list of strings', () {
+    Fuzzy fuse;
+    setUp(() {
+      fuse = setup(itemList: <String>[]);
+    });
+    test('empty result is returned', () {
+      final result = fuse.search('Bla');
+      expect(result.isEmpty, true);
+    });
+  });
+
   group('Flat list of strings: ["Apple", "Orange", "Banana"]', () {
     Fuzzy fuse;
     setUp(() {


### PR DESCRIPTION
Currently the search is crashing when the list is empty due to a RangeError. This commit fix the bug by returning an empty result when the list is empty.