### PR TITLE
Fix search crash tokenize with leading or trailing whitespace strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG
+## 0.2.2
+- Fix bug for search in a list with some string that has leading or trailing whitespace when tokenize option is true
+
 ## 0.2.1
 - Fix bug for search empty list
 

--- a/lib/fuzzy.dart
+++ b/lib/fuzzy.dart
@@ -81,7 +81,7 @@ class Fuzzy<T> {
       for (var i = 0, len = list.length; i < len; i += 1) {
         _analyze(
           key: '',
-          value: list[i].toString(),
+          value: list[i].toString().trim(),
           record: list[i],
           index: i,
           tokenSearchers: tokenSearchers,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fuzzy
-version: 0.2.1
+version: 0.2.2
 
 authors:
   - Igor Borges <igor@borges.dev>

--- a/test/fuzzy_test.dart
+++ b/test/fuzzy_test.dart
@@ -227,7 +227,8 @@ void main() {
 
       expect(result.length, 1, reason: 'we get a list of exactly 1 item');
       expect(result[0].item, equals(' Banana '),
-          reason: 'whose value is the same, disconsidering leading and trailing whitespace');
+          reason:
+              'whose value is the same, disconsidering leading and trailing whitespace');
     });
   });
 

--- a/test/fuzzy_test.dart
+++ b/test/fuzzy_test.dart
@@ -210,6 +210,27 @@ void main() {
     });
   });
 
+  group(
+      'Search with match all tokens in a list of strings with leading and trailing whitespace',
+      () {
+    Fuzzy fuse;
+    setUp(() {
+      final customList = [' Apple', 'Orange ', ' Banana '];
+      fuse = setup(
+        itemList: customList,
+        overwriteOptions: FuzzyOptions(tokenize: true),
+      );
+    });
+
+    test('When searching for the term "Banana"', () {
+      final result = fuse.search('Banana');
+
+      expect(result.length, 1, reason: 'we get a list of exactly 1 item');
+      expect(result[0].item, equals(' Banana '),
+          reason: 'whose value is the same, disconsidering leading and trailing whitespace');
+    });
+  });
+
   group('Search with match all tokens', () {
     Fuzzy fuse;
     setUp(() {


### PR DESCRIPTION
The search is crashing when the list contains some string that has leading or trailing whitespace and tokenize option is true. The fix calls trim() for each element from list when _analyze is called.