### PR TITLE
[fix] fix range errors, allow empty pattern, fixes #3, fixes #4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # CHANGELOG
+
+## 0.2.3
+- Fix some corner case bugs (empty search pattern, missing arguments)
+
 ## 0.2.2
 - Fix bug for search in a list with some string that has leading or trailing whitespace when tokenize option is true
 

--- a/lib/bitap/bitap_matched_indices.dart
+++ b/lib/bitap/bitap_matched_indices.dart
@@ -10,6 +10,9 @@ List<MatchIndex> matchedIndices(List<int> matchmask, int minMatchCharLength) {
   var end = -1;
   var i = 0;
 
+  // Abort if [matchmask] is empty
+  if (matchmask.isEmpty) return matchedIndices;
+
   for (var len = matchmask.length; i < len; i += 1) {
     var match = matchmask[i];
     if (match != 0 && start == -1) {

--- a/lib/bitap/bitap_search.dart
+++ b/lib/bitap/bitap_search.dart
@@ -1,8 +1,8 @@
 import 'dart:math';
 
-import 'data/match_score.dart';
 import 'bitap_matched_indices.dart';
 import 'bitap_score.dart';
+import 'data/match_score.dart';
 
 /// Executes a bitap search
 MatchScore bitapSearch(

--- a/lib/data/fuzzy_options.dart
+++ b/lib/data/fuzzy_options.dart
@@ -1,13 +1,15 @@
+import 'package:meta/meta.dart';
+
 import 'result.dart';
 
 /// Represents a weighted getter of an item
 class WeightedKey<T> {
   /// Instantiates it
   WeightedKey({
-    this.name,
-    this.getter,
-    this.weight,
-  }) : assert(weight > 0 && weight <= 1);
+    @required this.name,
+    @required this.getter,
+    @required this.weight,
+  }) : assert(weight >= 0 && weight <= 1);
 
   /// Name of this getter
   final String name;

--- a/lib/fuzzy.dart
+++ b/lib/fuzzy.dart
@@ -33,6 +33,17 @@ class Fuzzy<T> {
   List<Result<T>> search(String pattern, [int limit = -1]) {
     if (list.isEmpty) return <Result<T>>[];
 
+    // Return original list as [List<Result>] if pattern is empty
+    if (pattern == '') {
+      return list
+          .map((item) => Result<T>(
+                item: item,
+                matches: const [],
+                score: 0,
+              ))
+          .toList();
+    }
+
     final searchers = _prepareSearchers(pattern);
 
     final resultsAndWeights =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fuzzy
-version: 0.2.2
+version: 0.2.3
 
 authors:
   - Igor Borges <igor@borges.dev>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,10 +11,11 @@ repository: https://github.com/comigor/fuzzy
 issue_tracker: https://github.com/comigor/fuzzy/issues
 
 environment:
-  sdk: '>=2.6.0 <3.0.0'
+  sdk: ">=2.6.0 <3.0.0"
 
 dependencies:
   latinize: ^0.0.2
+  meta: ^1.1.8
 
 dev_dependencies:
   test: ^1.9.4


### PR DESCRIPTION
So, I haven't gone through the codebase enough yet to know if these are the "proper" fixes but I was running into a bunch of errors right off the bat and these seem to fix them, mostly allowing an empty pattern (which just returns the original list), and a couple of other range errors.

Thanks for this by the way! I got really excited when I saw this package as I was converting a React search that already used Fuse.js.

Needed to add the `meta` dependency for the `@required` annotation.

Signed-off-by: Daniel Mahon <danielmahon@users.noreply.github.com>