### PR TITLE
fix: Range error when using limit argument to fuse.search, closes #25

### DIFF
--- a/lib/fuzzy.dart
+++ b/lib/fuzzy.dart
@@ -55,7 +55,7 @@ class Fuzzy<T> {
       _sort(resultsAndWeights.results);
     }
 
-    if (limit > 0) {
+    if (limit > 0 && resultsAndWeights.results.length > limit) {
       return resultsAndWeights.results.sublist(0, limit);
     }
 


### PR DESCRIPTION
Fixes https://github.com/comigor/fuzzy/issues/25
Credit to @bradleybauer for providing solution in the comment to #25 