### PR TITLE
fix: Range error when using limit argument to fuse.search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.5.1
+- Range error when using limit argument to fuse.search, closes #25. [Original PR](https://github.com/comigor/fuzzy/pull/26).
+
 ## 0.5.0
 - Dart 3 support added.
 

--- a/lib/fuzzy.dart
+++ b/lib/fuzzy.dart
@@ -55,7 +55,7 @@ class Fuzzy<T> {
       _sort(resultsAndWeights.results);
     }
 
-    if (limit > 0) {
+    if (limit > 0 && resultsAndWeights.results.length > limit) {
       return resultsAndWeights.results.sublist(0, limit);
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fuzzy
-version: 0.5.0
+version: 0.5.1
 
 description: >
   Fuzzy search in Dart. Initially a code conversion, subset of Fuse.js.


### PR DESCRIPTION
Re-opened https://github.com/comigor/fuzzy/pull/26 to rebase, given I have to right to push to `digitevent:master`.